### PR TITLE
Hack to get manually save order details

### DIFF
--- a/app/BtcAutoTrader/Orders/OrderRepositoryEloquent.php
+++ b/app/BtcAutoTrader/Orders/OrderRepositoryEloquent.php
@@ -30,7 +30,7 @@ class OrderRepositoryEloquent implements OrderRepositoryInterface
         $order = (new Order())->where('order_id', $order_id)->first();
 
         //calculate the rate paid for this order (why it isn't returned from the API is a mystery)
-        $rate = 1 / $details->base * $details->counter;
+        $rate = $details->base ? 1 / $details->base * $details->counter : 0;
 
         $order->creation_timestamp = $details->creation_timestamp;
         $order->expiration_timestamp = $details->expiration_timestamp;

--- a/app/Http/Controllers/AutoTraderController.php
+++ b/app/Http/Controllers/AutoTraderController.php
@@ -26,12 +26,9 @@ class AutoTraderController extends Controller
         }
     }
 
-    public function orderDetails(string $order_id, BitX $bitXApi, OrderRepositoryInterface $orderRepository
-    )
+    public function orderDetails(string $order_id, BitX $bitXApi, OrderRepositoryInterface $orderRepository)
     {
         $orderDetails = $bitXApi->getOrderDetails($order_id);
-
-        dd($orderDetails);
-        //return $orderRepository->update($order->order_id, $orderDetails);
+        return $orderRepository->update($order_id, $orderDetails);
     }
 }

--- a/app/Http/Controllers/AutoTraderController.php
+++ b/app/Http/Controllers/AutoTraderController.php
@@ -2,7 +2,9 @@
 
 namespace App\Http\Controllers;
 
+use BtcAutoTrader\Api\BitX;
 use BtcAutoTrader\AutoTrader\AutoTrader;
+use BtcAutoTrader\Orders\OrderRepositoryInterface;
 use Illuminate\Support\Facades\Log;
 
 class AutoTraderController extends Controller
@@ -22,5 +24,14 @@ class AutoTraderController extends Controller
             Log::warning(__METHOD__.'(): Exception: '.$e->getMessage());
             return response($e->getMessage(), 500);
         }
+    }
+
+    public function orderDetails(string $order_id, BitX $bitXApi, OrderRepositoryInterface $orderRepository
+    )
+    {
+        $orderDetails = $bitXApi->getOrderDetails($order_id);
+
+        dd($orderDetails);
+        //return $orderRepository->update($order->order_id, $orderDetails);
     }
 }

--- a/routes/web.php
+++ b/routes/web.php
@@ -19,5 +19,6 @@ $app->post('/api/v1/exchange-rates/{from_iso}/{to_iso}', ['uses' => 'ExchangeRat
 $app->get('/api/v1/exchange-rates/bulk-update', ['uses' => 'ExchangeRatesController@bulkUpdate']);
 
 $app->post('/api/v1/auto-trade/', ['uses' => 'AutoTraderController@trade']);
+$app->get('/api/v1/order-details/{order_id}', ['uses' => 'AutoTraderController@orderDetails']);
 
 $app->get('/api/v1/xbt-gap', ['uses' => 'ExchangeRateGapController@index']);


### PR DESCRIPTION
There seems to be an issue when trying to get an order's details directly after placing the order. This leads to orders with not info. Because orders are placed to rarely, this can just be manually run once you notice an order with not details